### PR TITLE
refactor: Only add preconnect to the matomoserver if proxy tracking is disabled

### DIFF
--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -2,5 +2,8 @@
 
 {% block layout_head_meta_tags %}
     {{ parent() }}
-    <link rel="preconnect" crossorigin href="//{{ config("TinectMatomo.config.matomoserver") }}">
+
+    {% if not config('TinectMatomo.config.activateProxyTracking') %}
+        <link rel="preconnect" crossorigin href="//{{ config("TinectMatomo.config.matomoserver") }}">
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
I was just going through the code, and noticed that the `preconnect` is probably not required if proxy tracking is enabled.